### PR TITLE
fix: do not call `lightline#update()` if not defined

### DIFF
--- a/autoload/lightline/gitdiff.vim
+++ b/autoload/lightline/gitdiff.vim
@@ -2,11 +2,24 @@ function! lightline#gitdiff#get() abort
   return lightline#gitdiff#format(g:lightline#gitdiff#cache[bufnr('%')])
 endfunction
 
-" write_to_cache writes the information got from `git --numstat` into the
+" update writes the diff of the current buffer to the cache and calls a
+" callback function afterwards if it exists. The callback function can be
+" defined in `g:lightline#gitdiff#update_callback`.
+function! lightline#gitdiff#update(soft)
+  call s:write_diff_to_cache(a:soft)
+
+  let l:callback = get(g:, 'lightline#gitdiff#update_callback', 'lightline#update')
+
+  if exists('*' . l:callback)
+    execute 'call ' . l:callback . '()'
+  endif
+endfunction
+
+" write_diff_to_cache writes the information got from `git --numstat` into the
 " cache. There is an option to perform a "soft" write to reduce calls to `git`
 " when needed. Anyway, the function ensures that there is data in the cache
 " for the current buffer.
-function! lightline#gitdiff#write_to_cache(soft) abort
+function! s:write_diff_to_cache(soft) abort
   if a:soft && has_key(g:lightline#gitdiff#cache, bufnr('%'))
     " b/c there is something in the cache already
     return 

--- a/plugin/lightline/gitdiff.vim
+++ b/plugin/lightline/gitdiff.vim
@@ -4,8 +4,8 @@ let g:lightline#gitdiff#cache = {}
 
 augroup lightline#gitdiff
   autocmd!
-  " Use a hard write b/c buffer is new or changed
-  autocmd BufReadPost,BufWritePost * :call lightline#gitdiff#write_to_cache(v:false) | :call lightline#update()
-  " Soft write is possible b/c no buffer new or changed
-  autocmd BufEnter * :call lightline#gitdiff#write_to_cache(v:true) | :call lightline#update()
+  " Update hard b/c buffer is new or changed
+  autocmd BufReadPost,BufWritePost * :call lightline#gitdiff#update(v:false)
+  " Soft update is possible b/c no buffer new or changed
+  autocmd BufEnter * :call lightline#gitdiff#update(v:true)
 augroup end


### PR DESCRIPTION
b/c it should be possible to use this plugin in non-lightline contexts
too.

fixes #1