### PR TITLE
fix: remove superfluous separators if indicators are missing

### DIFF
--- a/autoload/lightline/gitdiff.vim
+++ b/autoload/lightline/gitdiff.vim
@@ -47,9 +47,11 @@ function! lightline#gitdiff#format(diff_dict) abort
   let l:separator = get(g:, 'lightline#gitdiff#separator', ' ')
 
   let l:diff_dict_mapping = { 'A': 'added', 'D': 'deleted', 'M': 'modified' }
-  let l:DiffDictKeyValueFormatter = { key, val -> has_key(a:diff_dict, key) ? get(g:, 'lightline#gitdiff#indicator_' . val, key . ': ') . a:diff_dict[key] : '' }
+  let l:DiffDictKeyValueFormatter = { key, val -> has_key(a:diff_dict, key) ?
+        \ get(g:, 'lightline#gitdiff#indicator_' . val, key . ': ') . a:diff_dict[key] : '' }
 
-  return join(values(filter(map(l:diff_dict_mapping, l:DiffDictKeyValueFormatter), { key, val -> val !=# '' })), l:separator)
+  return join(values(filter(map(l:diff_dict_mapping, l:DiffDictKeyValueFormatter),
+        \ { key, val -> val !=# '' })), l:separator)
 endfunction
 
 " calculate_numstat queries git to get the amount of lines that were added and/or


### PR DESCRIPTION
b/c `join()` adds a separator between elements even if they are an empty
string (` `), in this commit, these elements are removed before joining.
In addition, I refactored formatting indicator keys and their
corresponding value to remove redundant code.

fixes #5 